### PR TITLE
누락된 JwtAuthenticationFilter 의 변경 사항 핫픽스 

### DIFF
--- a/src/main/java/me/chan99k/learningmanager/common/config/WebConfig.java
+++ b/src/main/java/me/chan99k/learningmanager/common/config/WebConfig.java
@@ -20,8 +20,8 @@ public class WebConfig implements WebMvcConfigurer {
 	public FilterRegistrationBean<JwtAuthenticationFilter> jwtFilterRegistration() {
 		FilterRegistrationBean<JwtAuthenticationFilter> registration = new FilterRegistrationBean<>();
 		registration.setFilter(jwtAuthenticationFilter);
-		// 인증이 필요한 경로만 지정 (인증 불필요: /register, /auth/*, /activate)
-		registration.addUrlPatterns("/api/v1/members/profile/*");
+
+		registration.addUrlPatterns("/api/v1/members/profile");
 		registration.addUrlPatterns("/api/v1/admin/*");
 		registration.setOrder(1);
 


### PR DESCRIPTION
## 💡 Motivation and Context
> `이전 PR 에서 누락되었던 변경사항을 추가합니다`

<br>

## 🔨 Modified
- JwtAuthenticationFilter.java: HTTP 응답 직접 작성 로직 추가 (writeErrorResponse, escapeJsonString 메서드)
- WebConfig.java: JWT 필터 URL 패턴 수정 (/api/v1/members/profile)

    1. **커밋 f719278**을 feat/learning-manager-38_member_profile_update 브랜치에서 메인 브랜치로 체리픽
    2. JWT 필터가 이제 HTTP 응답을 직접 작성하는 방식으로 올바르게 업데이트됨
    3. 모든 테스트가 통과함 (175 tests completed, 0 failed)
  
<br>

## 🌟 More
> _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_
- 

<br>

---


### 📋 체크리스트
- [ ] 추가/변경에 대한 테스트
- [ ] 코드 컨벤션

<br>

### 🤟🏻 PR로 완료된 이슈
> closes #
