### PR TITLE
IssueTokenService에 트랜잭션 처리 추가 핫픽스

### DIFF
--- a/core/service/src/main/java/me/chan99k/learningmanager/auth/IssueTokenService.java
+++ b/core/service/src/main/java/me/chan99k/learningmanager/auth/IssueTokenService.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import me.chan99k.learningmanager.exception.DomainException;
 import me.chan99k.learningmanager.member.Account;
@@ -17,6 +18,7 @@ import me.chan99k.learningmanager.member.Member;
 import me.chan99k.learningmanager.member.MemberQueryRepository;
 
 @Service
+@Transactional
 public class IssueTokenService implements IssueToken {
 
 	private final MemberQueryRepository memberQueryRepository;
@@ -35,7 +37,11 @@ public class IssueTokenService implements IssueToken {
 		this.refreshTokenTtlHours = Duration.ofHours(refreshTokenTtlHours);
 	}
 
+	/**
+	 * JPA는 조회만 수행. RefreshToken은 인메모리/Redis에 저장됨.
+	 */
 	@Override
+	@Transactional(readOnly = true)
 	public Response issueToken(Request request) {
 		// 1. 이메일로 Member 조회
 		Email email = Email.of(request.email());


### PR DESCRIPTION
## 💡 Motivation and Context
> IssueTokenService 클래스에 트랜잭션 관련 애노테이션이 누락되어 있어 Hibernate 세션이 member 조회후 account 를 조회할 때까지 남아있지 않는 lazy-loading 관련 문제를 해결합니다.

<br>

## 🔨 Modified
- IssueTokenService 클래스에 누락된 @Transactional 애노테이션을 추가했습니다.
- 인메모리/Redis 작업과 트랜잭션 의존성이 없기 때문에 성능 최적화를 위해 issueToken 메서드를 readOnly = true로 설정했습니다.

<br>

## 🌟 More
> N/A

<br>

### 📋 체크리스트
- [ ] 추가/변경에 대한 테스트
- [ ] 코드 컨벤션

<br>

### 🤟🏻 PR로 완료된 이슈
> closes #